### PR TITLE
Move prep out of lab

### DIFF
--- a/module1/index.md
+++ b/module1/index.md
@@ -39,7 +39,7 @@ Students will learn the basics of Object Oriented Programming to build software 
 ### Week 4
 * Intro to IDE: [Prep](./preparation/Week4/IDE) [Lesson](./lessons/Week4/IntroToIDE) &#124; [Lab](./labs/Week4/IntrotoIDE)
 * Debugging: [Prep](./preparation/Week4/Debugging) [Lesson](./lessons/Week4/Debugging) &#124; [Lab](./labs/Week4/Debugging)
-* Unit Testing, Part 1: [Lesson](./lessons/Week4/UnitTestingI) &#124; [Lab](./labs/Week4/UnitTestingI)
+* Unit Testing, Part 1: [Prep](./preparation/Week4/UnitTesting) [Lesson](./lessons/Week4/UnitTestingI) &#124; [Lab](./labs/Week4/UnitTestingI)
 * [Week 4 - Check Your Understanding](./lessons/Week4/CFUReview)
 
 ### Week 5

--- a/module1/index.md
+++ b/module1/index.md
@@ -26,7 +26,7 @@ Students will learn the basics of Object Oriented Programming to build software 
 * Collections: [Lesson](./lessons/Week2/Collections) &#124; [Lab](./labs/Week2/Collections)
 * Asking Technical Questions That Lead to Answers: [Lesson](./lessons/Week2/AskingTechnicalQuestions)
 * Looping and Iteration: [Lesson](./lessons/Week2/Looping) &#124; [Lab](./labs/Week2/Looping)
-* Methods: [Lesson](./lessons/Week2/Methods) &#124; [Lab](./labs/Week2/Methods)
+* Methods: [Prep](./preparation/Week2/Methods) [Lesson](./lessons/Week2/Methods) &#124; [Lab](./labs/Week2/Methods)
 * [Week 2 - Check Your Understanding](./lessons/Week2/CFUReview)
 
 ### Week 3

--- a/module1/index.md
+++ b/module1/index.md
@@ -43,7 +43,7 @@ Students will learn the basics of Object Oriented Programming to build software 
 * [Week 4 - Check Your Understanding](./lessons/Week4/CFUReview)
 
 ### Week 5
-* Unit Testing, Part 2: [Lesson](./lessons/Week5/UnitTestingII) &#124; [Lab](./labs/Week5/UnitTestingII)
+* Unit Testing, Part 2: [Prep](./preparation/Week5/UnitTestingII.md) [Lesson](./lessons/Week5/UnitTestingII) &#124; [Lab](./labs/Week5/UnitTestingII)
 * Scope: [Lesson](./lessons/Week5/Scope)
 * Refactoring: [Lesson](./lessons/Week5/Refactoring) &#124; [Lab](./labs/Week5/Refactoring)
 * Using Technical Terminology: [Lesson](./lessons/Week5/TechnicalTerminology)

--- a/module1/index.md
+++ b/module1/index.md
@@ -37,8 +37,8 @@ Students will learn the basics of Object Oriented Programming to build software 
 * [Week 3 - Check Your Understanding](./lessons/Week3/CFUReview)
 
 ### Week 4
-* Intro to IDE: [Prep](./perparation/Week4/IDE) [Lesson](./lessons/Week4/IntroToIDE) &#124; [Lab](./labs/Week4/IntrotoIDE)
-* Debugging: [Lesson](./lessons/Week4/Debugging) &#124; [Lab](./labs/Week4/Debugging)
+* Intro to IDE: [Prep](./preparation/Week4/IDE) [Lesson](./lessons/Week4/IntroToIDE) &#124; [Lab](./labs/Week4/IntrotoIDE)
+* Debugging: [Prep](./preparation/Week4/Debugging) [Lesson](./lessons/Week4/Debugging) &#124; [Lab](./labs/Week4/Debugging)
 * Unit Testing, Part 1: [Lesson](./lessons/Week4/UnitTestingI) &#124; [Lab](./labs/Week4/UnitTestingI)
 * [Week 4 - Check Your Understanding](./lessons/Week4/CFUReview)
 

--- a/module1/index.md
+++ b/module1/index.md
@@ -30,7 +30,7 @@ Students will learn the basics of Object Oriented Programming to build software 
 * [Week 2 - Check Your Understanding](./lessons/Week2/CFUReview)
 
 ### Week 3
-* Classes: [Lesson](./lessons/Week3/Classes) &#124; [Lab](./labs/Week3/Classes)
+* Classes: [Prep](./preparation/Week3/Classes) [Lesson](./lessons/Week3/Classes) &#124; [Lab](./labs/Week3/Classes)
 * Productivity + Time Management: [Lesson](./lessons/Week3/ProductivityTimeMGMT)
 * Object Oriented Programming (OOP): [Lesson](./lessons/Week3/OOP) &#124; [Lab](./labs/Week3/OOP)
 * Class Interaction: [Lesson](./lessons/Week3/ClassInteraction) &#124; [Lab](./labs/Week3/ClassInteraction)

--- a/module1/index.md
+++ b/module1/index.md
@@ -37,7 +37,7 @@ Students will learn the basics of Object Oriented Programming to build software 
 * [Week 3 - Check Your Understanding](./lessons/Week3/CFUReview)
 
 ### Week 4
-* Intro to IDE: [Lesson](./lessons/Week4/IntroToIDE) &#124; [Lab](./labs/Week4/IntrotoIDE)
+* Intro to IDE: [Prep](./perparation/Week4/IDE) [Lesson](./lessons/Week4/IntroToIDE) &#124; [Lab](./labs/Week4/IntrotoIDE)
 * Debugging: [Lesson](./lessons/Week4/Debugging) &#124; [Lab](./labs/Week4/Debugging)
 * Unit Testing, Part 1: [Lesson](./lessons/Week4/UnitTestingI) &#124; [Lab](./labs/Week4/UnitTestingI)
 * [Week 4 - Check Your Understanding](./lessons/Week4/CFUReview)

--- a/module1/labs/Week2/Collections.md
+++ b/module1/labs/Week2/Collections.md
@@ -108,14 +108,4 @@ string[] users = "Mike, Alice, Bob".Split(',');
 string[] users = "Mike, Alice, Bob".Split(", ");
 ```
 
-## Preparation
 
-Up to this point, we have used pre-built tools like `.Split()`,  `.ToLower()`, and `.Add()` to help us in our programming.  These tools are called **methods** - they are sets of instructions that can be _reused_ as needed.  We are going to learn more about methods in the next lesson, but to get you thinking about this topic, you could imagine that methods are like tools in a tool-box.  
-
-Let's say you are building a piece of furniture that requires you to fasten pieces together with nails.  The hammer in your tool box is like a method - when you need to fasten a nail, you use the hammer.  You can reuse the hammer whenever you want, without having to build or buy a new hammer for each nail.
-
-There are many pre-built methods that we can use in c# (or in any other language); but, the real power of programming is in building our own methods.   We can build specialized tools that can be reused in our programs to accomplish specific, repeated tasks.  These methods might be simple, like adding two numbers; or, complex, like building a user profile. Simple or complex, the goal of creating methods is to reduce any repeated instructions in our code.  where we see the same set of instructions being used over and over, we can clean up our code by organizing those instructions into **methods**.
-
-In your notebook, create a list of the built-in methods you have used recently.  What is the name of the method, and what does it do?
-
-**Keep an Eye on slack** we will be coming back together to do a quick oerview of .Split(), and the definition of **method**.

--- a/module1/labs/Week2/Methods.md
+++ b/module1/labs/Week2/Methods.md
@@ -98,17 +98,3 @@ console.WriteLine(jwords);
 <aside class="instructor-notes">
     <p><strong>Instructor Note</strong><br> We want to highlight student solutions to the first 3 exercises, and discuss good examples of psuedo-code for the last 3 exercises.</p>
 </aside>
-
-
-## Preparation
-### Namespaces
-
-As our programs get more complex, we will start working with more built-in c# tools and we will start writing code in multiple files.  With the increased complexity, we will need to be intentional about how we organize the code that we write.  One way that c# helps us with this organization is with `namespaces`.  Read through the two resources listed below:
-
-* [Microsoft Docs](https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/types/namespaces)
-* [Tutorials Point](https://www.tutorialspoint.com/csharp/csharp_namespaces.htm)
-
-And, answer these questions in your notebook:
-* Why do we use the line `using System;` at the top of our program.cs file?
-* Is `using System;` required for our programs to execute?  Why, or why not?
-* In your own words, what is a `namespace`?

--- a/module1/labs/Week3/ClassInteraction.md
+++ b/module1/labs/Week3/ClassInteraction.md
@@ -64,11 +64,5 @@ List<string> allBooksTitles = denverPublicLibrary.AllBooks();
 
 **Keep nn Eye on Slack!** We will be coming back together a few times to answer questions and any common issues that are coming up.
 
-## Preparation
 
-Up to this point, we've been using [Replit](https://replit.com/), an online version of an IDE (Integrated Development Environment). It is a great environment to learn the basics of programming. In fact, Replit supports dozens of programming languages, not just C#. However, to become a professional developer, we need to use more dedicated tools.
-
-As our first step, we will install an IDE called Visual Studio directly on our machines. While there are several versions of Visual Studio, we will use the FREE version called **Visual Studio Community**. Learn more about Visual Studio [here](https://visualstudio.microsoft.com/vs/). We will work through the installation process in the next lesson.
-
-Before we install Visual Studio, we need to install Git on our local machine. [Follow these instructions to install Git](/module1/lessons/Week3/InstallGit). We won't use it right away, but it will be important as we continue working on new and existing projects.
 

--- a/module1/labs/Week3/ClassInteraction.md
+++ b/module1/labs/Week3/ClassInteraction.md
@@ -62,7 +62,7 @@ List<string> allBooksTitles = denverPublicLibrary.AllBooks();
 // { "To Kill a Mockingbird", "Mockingjay", "The Fault In Our Stars", "Catching Fire",  "The Hunger Games" }
 ```
 
-**Keep nn Eye on Slack!** We will be coming back together a few times to answer questions and any common issues that are coming up.
+**Keep an Eye on Slack!** We will be coming back together a few times to answer questions and any common issues that are coming up.
 
 
 

--- a/module1/labs/Week4/Debugging.md
+++ b/module1/labs/Week4/Debugging.md
@@ -92,10 +92,3 @@ Total: $46.64
     <li>23> Instead of replacing `", "`, they should repleace `"\n"` to get the correct price calculation.</li>
   </ul>
 </aside>
-
-## Preparation
-
-Individually, spend 10-15 minutes reflecting on the following questions. Take notes on your reflection to share out in tomorrow's lesson warm-up.
-
-* Up to now, how have you known if your code was functioning?
-* Imagine you are a developer working at Google; what might be some drawbacks to your current approach?

--- a/module1/labs/Week4/IntrotoIDE.md
+++ b/module1/labs/Week4/IntrotoIDE.md
@@ -62,7 +62,3 @@ For example:
     * Nominate 1 person to share out 1 interesting thing your group discussed.
 
 **Keep an eye on Slack** We will be coming together to discuss your reflections!
-
-## Preparation
-
-Tomorrow, we are going to be discussing **debugging**.  Spend 5-10 minutes googling to come up with a definition of **debugging**; you could try phrases like `what is a bug in programming?`, `debugging code`, `c# debugging tools`.  In your notebook, write out your definition of debugging.

--- a/module1/labs/Week5/Refactoring.md
+++ b/module1/labs/Week5/Refactoring.md
@@ -25,9 +25,3 @@ For today's exercise, you will:
 3. Spend 40 minutes refactoring the code to better adhere to SRP
 
 Be Prepared to share out the responsibilities you identified, and the refactors you have made (or are making).  We will come together periodically as a group to share and discuss.
-
-## Preparation
-
-In your noteboook, reflect on the following:
-1. During the lesson and this lab, how did you know if your refactor was or was not breaking the function of the program?
-2. What if these examples had included tests?  Would that have impacted your ability to refactor the code?  Why or why not?

--- a/module1/lessons/Week2/Looping.md
+++ b/module1/lessons/Week2/Looping.md
@@ -212,6 +212,7 @@ In any looping statement, we refer to each *loop* as an **iteration**.  Each tim
 > {
 >   Console.WriteLine($"Counter is: {counter}");
 > }
+>```
 
 
 ### Check for Understanding

--- a/module1/preparation/Week2/Methods.md
+++ b/module1/preparation/Week2/Methods.md
@@ -1,7 +1,4 @@
----
-layout: page
-title: Methods Prep
----
+
 
 ### Preparation
 

--- a/module1/preparation/Week2/Methods.md
+++ b/module1/preparation/Week2/Methods.md
@@ -1,0 +1,17 @@
+---
+layout: page
+title: Methods Prep
+---
+
+### Preparation
+
+Up to this point, we have used pre-built tools like `.Split()`,  `.ToLower()`, and `.Add()` to help us in our programming.  These tools are called **methods** - they are sets of instructions that can be _reused_ as needed.  We are going to learn more about methods in the next lesson, but to get you thinking about this topic, you could imagine that methods are like tools in a tool-box.  
+
+Let's say you are building a piece of furniture that requires you to fasten pieces together with nails.  The hammer in your tool box is like a method - when you need to fasten a nail, you use the hammer.  You can reuse the hammer whenever you want, without having to build or buy a new hammer for each nail.
+
+
+There are many pre-built methods that we can use in c# (or in any other language); but, the real power of programming is in building our own methods.   We can build specialized tools that can be reused in our programs to accomplish specific, repeated tasks.  These methods might be simple, like adding two numbers; or, complex, like building a user profile. Simple or complex, the goal of creating methods is to reduce any repeated instructions in our code.  where we see the same set of instructions being used over and over, we can clean up our code by organizing those instructions into **methods**.
+
+In your notebook, create a list of the built-in methods you have used recently.  What is the name of the method, what does it do, and what does it's syntax look like? 
+
+

--- a/module1/preparation/Week3/Classes.md
+++ b/module1/preparation/Week3/Classes.md
@@ -1,0 +1,26 @@
+---
+layout: page
+title: Classes Prep
+---
+
+# Preparation
+## Classes
+So far, we've used basic data types like `strings`, `bool`'s, and `int`'s or `double`'s as the data in our applications so far. We've even seen how we can track more complicated pairs of data like items and their quantity in a hypothetical inventory system using a `Dictonary`. But consider how we might keep track of the many pieces of data involved with a `user` in an app like Instagram.
+
+<section class="call-to-action" markdown="1">
+### In Your Notebook
+- What are some `properties` the user might have? These are piece of data like `username`, `friends` or `age` - brainstorm at least three more properties.
+- What are some `behaviors` or actions a user needs to be able to take? Brainstorm at least three more behaviors.
+</section>
+
+## Namespaces
+
+As our programs get more complex, we will start working with more built-in c# tools and we will start writing code in multiple files.  With the increased complexity, we will need to be intentional about how we organize the code that we write.  One way that c# helps us with this organization is with `namespaces`.  Read through the two resources listed below:
+
+* [Microsoft Docs](https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/types/namespaces)
+* [Tutorials Point](https://www.tutorialspoint.com/csharp/csharp_namespaces.htm)
+
+And, answer these questions in your notebook:
+* Why do we use the line `using System;` at the top of our program.cs file?
+* Is `using System;` required for our programs to execute?  Why, or why not?
+* In your own words, what is a `namespace`?

--- a/module1/preparation/Week3/Classes.md
+++ b/module1/preparation/Week3/Classes.md
@@ -9,8 +9,10 @@ So far, we've used basic data types like `strings`, `bool`'s, and `int`'s or `do
 
 <section class="call-to-action" markdown="1">
 ### In Your Notebook
-- What are some `properties` the user might have? These are piece of data like `username`, `friends` or `age` - brainstorm at least three more properties.
+- What are some `properties` the user might have? These are piece of data like `username`, `friends` or `age` - brainstorm at least three more properties and what their datatype might be.
 - What are some `behaviors` or actions a user needs to be able to take? Brainstorm at least three more behaviors.
+
+It would be a nightmare to track all of this data in separate variables. This is where `Classes` come into play. Do some research and write down your current definition of what a `Class` is in C#.
 </section>
 
 ## Namespaces

--- a/module1/preparation/Week4/Debugging.md
+++ b/module1/preparation/Week4/Debugging.md
@@ -1,0 +1,9 @@
+---
+layout: page
+title:  Debugging Prep
+---
+
+## Preparation
+
+Tomorrow, we are going to be discussing **debugging**.  Spend 5-10 minutes googling to come up with a definition of **debugging**; you could try phrases like `what is a bug in programming?`, `debugging code`, `c# debugging tools` and `Where did the term bug come from in programming?`.  
+In your notebook, write out your definition of debugging. Write down some examples of real life debugging you might have already had experience with.

--- a/module1/preparation/Week4/IDE.md
+++ b/module1/preparation/Week4/IDE.md
@@ -1,0 +1,12 @@
+---
+layout: page
+title: IDE Prep
+---
+
+## Preparation
+
+Up to this point, we've been using [Replit](https://replit.com/), an online version of an IDE (Integrated Development Environment). It is a great environment to learn the basics of programming. In fact, Replit supports dozens of programming languages, not just C#. However, to become a professional developer, we need to use more dedicated tools.
+
+As our first step, we will install an IDE called Visual Studio directly on our machines. While there are several versions of Visual Studio, we will use the FREE version called **Visual Studio Community**. Learn more about Visual Studio [here](https://visualstudio.microsoft.com/vs/). We will work through the installation process in the next lesson.
+
+Before we install Visual Studio, we need to install Git on our local machine. [Follow these instructions to install Git](/module1/lessons/Week3/InstallGit). We won't use it right away, but it will be important as we continue working on new and existing projects.

--- a/module1/preparation/Week4/UnitTesting.md
+++ b/module1/preparation/Week4/UnitTesting.md
@@ -1,0 +1,11 @@
+---
+layout: page
+title:  Unit Testing Prep
+---
+
+# Preparation
+
+Individually, spend 10-15 minutes reflecting on the following questions. Take notes on your reflection to share out in tomorrow's lesson warm-up.
+
+* In your brief programming experience, how have you known if your code was functioning as expected?
+* Imagine you are a developer working at Google on some large-scale projects; what might be some drawbacks to your current approach?

--- a/module1/preparation/Week5/UnitTestingII.md
+++ b/module1/preparation/Week5/UnitTestingII.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title:  Unit Testing Part 2 Prep
+---
+
+# Preparation
+
+In your noteboook, reflect on the following:
+1. During the lesson and this lab, how did you know if your refactor was or was not breaking the function of the program?
+2. What if these examples had included tests?  Would that have impacted your ability to refactor the code?  Why or why not?


### PR DESCRIPTION
This PR closes issue turingschool/launch-curriculum#238

## Summary of changes requested: 
- Move prep out of the labs, and into their own pages on the curriculum site
- update the links on the curriculum site to provide access to the prep pages

### Changes Made:
- [x] All of the above
- [x] Fixed some minor typos or issues with code formatting
- [x] Expanded on the `Classes` prep from just focusing on `namespaces` to `namespaces` and brainstorming some properties and behaviors of an Instagram user
